### PR TITLE
Add binder support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib/
 node_modules/
 *.egg-info/
 .ipynb_checkpoints
+*/__pycache__/*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -18,16 +18,29 @@ We haven't published the component yet, but we will soon. In the meantime, you'l
 ```bash
 git clone https://github.com/plotly/jupyterlab-dash
 cd jupyterlab-dash
-npm install
-npm run build
+# Install Python package
+pip install -e .
+# Install Javascript dependencies
+npm install # or yarn
+# Build JupyterLab extension
+npm run build # or yarn build
 jupyter labextension link .
 ```
 
-To rebuild the package and the JupyterLab app:
+To rebuild the JupyterLab extension:
 
 ```bash
 npm run build
 jupyter lab build
+```
+
+To rebuild the JupyterLab extension automatically as the source changes:
+
+```bash
+# In one terminal tab, watch the jupyterlab-dash directory
+npm run watch # or yarn watch
+# In another terminal tab, run jupyterlab with the watch flag
+jupyter lab --watch
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # jupyterlab_dash
 
+[![Binder](https://beta.mybinder.org/badge.svg)](https://mybinder.org/v2/gh/plotly/jupyterlab-dash/master?urlpath=lab%2Ftree%2Fnotebooks)
+
 A JupyterLab extension for rendering Plotly Dash apps as a separate window in JupyterLab :tada:
 
 ![JupyterLab and Dash Demo Video](https://user-images.githubusercontent.com/1280389/47668836-da9f4280-db7f-11e8-8523-8663b6a5347f.gif)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ A JupyterLab extension for rendering Plotly Dash apps as a separate window in Ju
 
 ## Prerequisites
 
-* JupyterLab
-
+- JupyterLab
 
 ## Installation
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Install Python package
+pip install -e .
+# Install Javascript dependencies
+npm install # or yarn
+# Build JupyterLab extension
+npm run build # or yarn build
+# Install JupyterLab extension
+jupyter labextension install .

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,4 @@
+jupyterlab>=0.35.0
+jupyter-server-proxy
+pandas
+dash

--- a/jupyterlab_dash/__init__.py
+++ b/jupyterlab_dash/__init__.py
@@ -71,7 +71,8 @@ class AppViewer(object):
             self._dash_comm.send({
                 'type': 'show',
                 'uid': self.uid,
-                'url': 'http://{}:{}'.format(resolved_host, launch_kwargs['port'])
+                'url': 'http://{}:{}'.format(resolved_host, launch_kwargs['port']),
+                'port': launch_kwargs['port']
             })
         else:
             # Failed to start development server

--- a/jupyterlab_dash/__init__.py
+++ b/jupyterlab_dash/__init__.py
@@ -2,10 +2,11 @@ import multiprocessing
 import socket
 import uuid
 from queue import Empty
-
-from ipykernel.comm import Comm
+from urllib.parse import urlparse
 import sys
 
+from ipykernel.comm import Comm
+from notebook import notebookapp
 
 class StdErrorQueue(object):
     def __init__(self):
@@ -33,6 +34,13 @@ class AppViewer(object):
             # Serve App
             sys.stdout = self.stderr_queue
             sys.stderr = self.stderr_queue
+
+            # Set pathname prefix for jupyter-server-proxy
+            url = next(notebookapp.list_running_servers())['url']
+
+            path = urlparse(url).path
+            app.config.update({'requests_pathname_prefix': f'{path}proxy/{self.port}/'})
+            
             app.run_server(debug=False, *args, **kwargs)
 
         # Terminate any existing server process

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build": "tsc",
     "clean": "rimraf lib",
     "prepare": "npm run clean && npm run build",
+    "prettier": "prettier --write '{!(package),src/**,!(lib)/**}{.js,.jsx,.ts,.tsx,.css,.json,.md}'",
     "watch": "tsc -w"
   },
   "dependencies": {
@@ -35,6 +36,7 @@
     "@jupyterlab/console": "^0.19.1"
   },
   "devDependencies": {
+    "prettier": "^1.11.1",
     "rimraf": "^2.6.1",
     "typescript": "~3.1.1"
   },

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,6 @@ from setuptools import setup
 setup(
     name='jupyterlab_dash',
     version='0.1',
-    packages=['jupyterlab_dash']
+    packages=['jupyterlab_dash'],
+    install_requires=['dash']
 )

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ setup(
     name='jupyterlab_dash',
     version='0.1',
     packages=['jupyterlab_dash'],
-    install_requires=['dash']
+    install_requires=['dash', 'jupyter-server-proxy']
 )

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,26 +4,17 @@ import {
   JupyterLabPlugin
 } from '@jupyterlab/application';
 
-import { IConsoleTracker } from '@jupyterlab/console';
-
 import { PageConfig } from '@jupyterlab/coreutils';
-
-//
-// import {
-//   JSONExt
-// } from '@phosphor/coreutils';
-
-import { Message } from '@phosphor/messaging';
-
-// import {
-//   InstanceTracker
-// } from '@jupyterlab/apputils';
 
 import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
 
-import { Widget } from '@phosphor/widgets';
-
 import { KernelMessage, Kernel } from '@jupyterlab/services';
+
+import { IConsoleTracker } from '@jupyterlab/console';
+
+import { Message } from '@phosphor/messaging';
+
+import { Widget } from '@phosphor/widgets';
 
 import '../style/index.css';
 
@@ -38,7 +29,6 @@ class DashIFrameWidget extends Widget {
     super();
 
     this.id = uid;
-    this.url = url;
     this.title.label = 'Dash';
     this.title.closable = true;
     this.addClass('jp-dashWidget');
@@ -63,11 +53,6 @@ class DashIFrameWidget extends Widget {
    * The image element associated with the widget.
    */
   readonly iframe: HTMLIFrameElement;
-
-  /**
-   * URL
-   */
-  readonly url: string;
 
   /**
    * Handle update requests for the widget.
@@ -129,13 +114,6 @@ function activate(
       });
     });
   });
-  // // Track and restore the widget state
-  // let tracker = new InstanceTracker<Widget>({ namespace: 'xkcd' });
-  // restorer.restore(tracker, {
-  //   command,
-  //   args: () => JSONExt.emptyObject,
-  //   name: () => 'plotly-dash'
-  // });
 }
 
 function registerCommTarget(

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import {
 
 import { IConsoleTracker } from '@jupyterlab/console';
 
+import { PageConfig } from '@jupyterlab/coreutils';
+
 //
 // import {
 //   JSONExt
@@ -32,7 +34,7 @@ class DashIFrameWidget extends Widget {
   /**
    * Construct a new DashIFrameWidget.
    */
-  constructor(uid: string, url: string) {
+  constructor(uid: string, url: string, port: string) {
     super();
 
     this.id = uid;
@@ -46,10 +48,12 @@ class DashIFrameWidget extends Widget {
     // See https://github.com/jupyterlab/jupyterlab/blob/master/packages/apputils/style/iframe.css#L17-L35
     this.addClass('jp-IFrame');
 
-    let iframeElement = document.createElement('iframe');
-    iframeElement.setAttribute('baseURI', '');
+    const baseUrl = PageConfig.getBaseUrl();
+    const serviceUrl = `${baseUrl}proxy/${port}`;
+    const iframeElement = document.createElement('iframe');
+    iframeElement.setAttribute('baseURI', serviceUrl);
     this.iframe = iframeElement;
-    this.iframe.src = url;
+    this.iframe.src = serviceUrl;
     this.iframe.id = 'iframe-' + this.id;
 
     this.node.appendChild(this.iframe);
@@ -77,6 +81,7 @@ interface DashMessageData {
   type: string;
   uid: string;
   url: string;
+  port: string;
 }
 
 /**
@@ -152,7 +157,11 @@ function registerCommTarget(
           if (!widgets.has(msgData.uid)) {
             // Create a new widget
             console.log('Create new widget');
-            widget = new DashIFrameWidget(msgData.uid, msgData.url);
+            widget = new DashIFrameWidget(
+              msgData.uid,
+              msgData.url,
+              msgData.port
+            );
             widget.update();
             widgets.set(msgData.uid, widget);
 

--- a/style/index.css
+++ b/style/index.css
@@ -1,6 +1,6 @@
-.jp-dashWidget iframe{
-    height:100%;
-    width:100%;
-    padding: 20px;
-    box-sizing: border-box;
+.jp-dashWidget iframe {
+  height: 100%;
+  width: 100%;
+  padding: 20px;
+  box-sizing: border-box;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -649,6 +649,10 @@ postcss@^6.0.14:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
+prettier@^1.11.1:
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"


### PR DESCRIPTION
This uses jupyter-server-proxy to allow jupyterlab-dash to communicate with dash without accessing arbitrary ports (which mybinder doesn't allow). 

Demo binder: https://mybinder.org/v2/gh/gnestor/jupyterlab-dash/binder?urlpath=lab%2Ftree%2Fnotebooks%2Ftest_app_viewer.ipynb

## To do
* [x] Detect if JupyterHub and if so, use `/hub/user-redirect/proxy/8080` path vs.  `/proxy/8080`: https://jupyter-server-proxy.readthedocs.io/en/latest/arbitrary-ports.html#with-jupyterhub
  * Binder is running JupyterHub so this works in JH. I haven't tested in a multi-user JH, but it sounds like it should work...