### PR TITLE
Remove f-string for < 3.5 support

### DIFF
--- a/jupyterlab_dash/__init__.py
+++ b/jupyterlab_dash/__init__.py
@@ -83,7 +83,7 @@ $ jupyter labextension install jupyterlab-dash
                 # Set pathname prefix for jupyter-server-proxy
                 path = urlparse(jupyterlab_url).path
                 app.config.update({
-                    'requests_pathname_prefix': f'{path}proxy/{self.port}/'})
+                    'requests_pathname_prefix': '{}proxy/{}/'.format(path, self.port)})
 
                 app.run_server(debug=False, *args, **kwargs)
 


### PR DESCRIPTION
Hello! For issue plotly/jupyterlab-dash#26

Format() method work out of the box with with Python 2.7, 3.2, 3.3, 3.4, and 3.5.